### PR TITLE
two-way binding on editor elements enable

### DIFF
--- a/src/common/widget-base.js
+++ b/src/common/widget-base.js
@@ -10,7 +10,7 @@ export class WidgetBase {
 */
   createWidget(option) {
     this.allOption = this.getWidgetOptions(option.element);
-    if (!this.ejOptions && !this.isEditor) {
+    if (!this.ejOptions && this.isEditor) {
       this.createTwoWays();
     }
     this.eWidget = this.widget = jQuery($(option.element))[this.controlName](this.allOption).data(this.controlName);


### PR DESCRIPTION
Two way data-binding on controls that uses hidden element like dropdown, dateTimePicker was not working.